### PR TITLE
Fix: Visual notifications not working in MCP context

### DIFF
--- a/notify-claude.sh
+++ b/notify-claude.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# notify-claude.sh - Helper script for Claude notifications
+# Usage: ./notify-claude.sh "Title" "Message" [start|complete]
+
+# Set title from first argument or default
+TITLE="${1:-Claude Notification}"
+
+# Set message from second argument or default
+MESSAGE="${2:-Task completed}"
+
+# Determine notification type (start or complete)
+# Default to complete if not specified
+NOTIFICATION_TYPE="${3:-complete}"
+
+# Set sound based on notification type
+if [[ "$NOTIFICATION_TYPE" == "start" ]]; then
+    SOUND_FILE="/System/Library/Sounds/Glass.aiff"
+else
+    SOUND_FILE="/System/Library/Sounds/Hero.aiff"
+fi
+
+# Try terminal-notifier first (most reliable method)
+if command -v terminal-notifier &> /dev/null; then
+    # Use terminal-notifier with user-specific icon
+    CLAUDE_ICON="/Applications/Claude.app/Contents/Resources/AppIcon.icns"
+    
+    if [[ -f "$CLAUDE_ICON" ]]; then
+        terminal-notifier -title "$TITLE" -message "$MESSAGE" -contentImage "$CLAUDE_ICON" -sender "com.apple.Terminal" -activate "com.anthropic.claude"
+    else
+        terminal-notifier -title "$TITLE" -message "$MESSAGE" -sender "com.apple.Terminal" -activate "com.anthropic.claude"
+    fi
+    NOTIFY_STATUS=$?
+else
+    NOTIFY_STATUS=1  # Set to error to try next method
+fi
+
+# If terminal-notifier failed or doesn't exist, try AppleScript
+if [[ $NOTIFY_STATUS -ne 0 ]]; then
+    # Enhanced AppleScript approach
+    osascript <<EOF
+    tell application "System Events"
+        display notification "$MESSAGE" with title "$TITLE"
+    end tell
+    delay 0.5
+EOF
+    NOTIFY_STATUS=$?
+fi
+
+# Play sound regardless of notification display status
+if [[ -f "$SOUND_FILE" ]]; then
+    afplay "$SOUND_FILE"
+    SOUND_STATUS=$?
+else
+    # Fallback to basic sounds if files not found
+    if [[ "$NOTIFICATION_TYPE" == "start" ]]; then
+        afplay /System/Library/Sounds/Ping.aiff
+    else
+        afplay /System/Library/Sounds/Submarine.aiff
+    fi
+    SOUND_STATUS=$?
+fi
+
+# Generate JSON response for the MCP server
+echo "{ \"status\": \"$([ $NOTIFY_STATUS -eq 0 ] && echo "success" || echo "error")\", \"message\": \"$MESSAGE\", \"sound\": \"$SOUND_FILE\", \"visual\": $([ $NOTIFY_STATUS -eq 0 ] && echo "true" || echo "false") }"
+
+exit $([ $NOTIFY_STATUS -eq 0 -o $SOUND_STATUS -eq 0 ] && echo 0 || echo 1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "notifications-mcp-server"
-version = "1.1.0"
+version = "1.2.1"
 description = "MCP server for Claude Desktop sound and visual notifications on macOS"
 authors = [
     {name = "Charles Adedotun", email = "charles.adedotun8@gmail.com"}


### PR DESCRIPTION
## Summary
This PR fixes the issue where visual notifications work in the test script but not when Claude invokes the `task_status` tool through the MCP server.

Fixes #3

## Changes
- Added a helper script (`notify-claude.sh`) that handles notifications outside the MCP context
- Enhanced the AppleScript notification method with better error handling and reliability
- Improved the terminal-notifier implementation with more robust options
- Updated the `task_status` tool to prioritize using the helper script
- Added detailed logging for easier debugging
- Bumped version to 1.2.1

## Implementation Details
The core solution adds a helper script approach that runs notifications in a separate context from the MCP server. This bypasses the permission restrictions that prevent visual notifications from working in the MCP context.

The helper script uses multiple methods (terminal-notifier and AppleScript) with automatic fallbacks to ensure at least one notification method works. It also returns JSON output for seamless integration with the Python code.

## Testing
The solution has been tested and successfully shows both sound and visual notifications when:
- Running the test script directly
- Having Claude invoke the `task_status` tool via the MCP server

## Documentation
No documentation changes were required, as this is a backend fix that doesn't change the user-facing interface.

## Additional Notes
This PR provides a more robust notification system with multiple layers of fallbacks, ensuring users receive both audible and visual notifications when Claude starts processing and completes a task.