### PR TITLE
Fix: Add explicit permissions to GitHub Actions workflow

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+# Add workflow-level permissions with least privilege principle
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR addresses two code scanning alerts by adding explicit permissions to the GitHub Actions workflow file. 

## Changes
- Added workflow-level permissions with the least privilege principle
- Set 'contents: read' permission which is sufficient for the current workflow tasks

## Related Issues
Fixes code scanning alerts #1 and #2 related to missing workflow permissions.

## Security Impact
This change improves security by following the principle of least privilege, ensuring the workflow only has the minimum permissions required to function properly.